### PR TITLE
Fix License link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- shields -->
 [![](https://img.shields.io/github/issues/mojira/r-isa)](https://github.com/mojira/r-isa/issues)
 [![](https://img.shields.io/github/stars/mojira/r-isa)](https://github.com/mojira/r-isa/stargazers)
-[![](https://img.shields.io/github/license/mojira/r-isa)](https://github.com/mojira/r-isa/blob/master/LICENSE)
+[![](https://img.shields.io/github/license/mojira/r-isa)](https://github.com/mojira/r-isa/blob/master/LICENSE.md)
 
 # r/isa
 


### PR DESCRIPTION
## Purpose
The link to the license in README.md is to a file named LICENSE, which is non-existent. The correct file is LICENSE.md.
## Approach
Correct the name of this file within the link in the README.md file.